### PR TITLE
Enable standalone tests

### DIFF
--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -91,13 +91,12 @@ jobs:
       displayName: 'Testing: standard'
       timeoutInMinutes: "10"
 
-    # TODO: need to check what is going wrong...
-    #- bash: bash run_standalone_tests.sh
-    #  workingDirectory: tests
-    #  env:
-    #    PL_RUN_CUDA_TESTS: "1"
-    #  displayName: 'Testing: standalone tests'
-    #  timeoutInMinutes: "10"
+    - bash: bash run_standalone_tests.sh
+      workingDirectory: tests
+      env:
+        PL_RUN_CUDA_TESTS: "1"
+      displayName: 'Testing: standalone tests'
+      timeoutInMinutes: "10"
 
     - bash: |
         python -m coverage report

--- a/tests/run_standalone_tests.sh
+++ b/tests/run_standalone_tests.sh
@@ -20,6 +20,9 @@ set -e
 test_batch_size="${PL_STANDALONE_TESTS_BATCH_SIZE:-6}"
 source="${PL_STANDALONE_TESTS_SOURCE:-"lightning_colossalai"}"
 
+# this environment variable allows special tests to run
+export PL_RUN_STANDALONE_TESTS=1
+
 # python arguments
 defaults="-m coverage run --source $source --append -m pytest --no-header -v -s"
 

--- a/tests/run_standalone_tests.sh
+++ b/tests/run_standalone_tests.sh
@@ -48,11 +48,11 @@ function show_batched_output {
   if [ -f standalone_test_output.txt ]; then  # if exists
     cat standalone_test_output.txt
     # heuristic: stop if there's mentions of errors. this can prevent false negatives when only some of the ranks fail
-    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
-      echo "Potential error! Stopping."
-      cat standalone_test_output.txt
-      exit 1
-    fi
+#    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
+#      echo "Potential error! Stopping."
+#      rm standalone_test_output.txt
+#      exit 1
+#    fi
     rm standalone_test_output.txt
   fi
 }

--- a/tests/run_standalone_tests.sh
+++ b/tests/run_standalone_tests.sh
@@ -48,11 +48,11 @@ function show_batched_output {
   if [ -f standalone_test_output.txt ]; then  # if exists
     cat standalone_test_output.txt
     # heuristic: stop if there's mentions of errors. this can prevent false negatives when only some of the ranks fail
-#    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
-#      echo "Potential error! Stopping."
-#      rm standalone_test_output.txt
-#      exit 1
-#    fi
+    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
+      echo "Potential error! Stopping."
+      cat standalone_test_output.txt
+      exit 1
+    fi
     rm standalone_test_output.txt
   fi
 }

--- a/tests/run_standalone_tests.sh
+++ b/tests/run_standalone_tests.sh
@@ -51,11 +51,11 @@ function show_batched_output {
   if [ -f standalone_test_output.txt ]; then  # if exists
     cat standalone_test_output.txt
     # heuristic: stop if there's mentions of errors. this can prevent false negatives when only some of the ranks fail
-    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
-      echo "Potential error! Stopping."
-      rm standalone_test_output.txt
-      exit 1
-    fi
+#    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
+#      echo "Potential error! Stopping."
+#      rm standalone_test_output.txt
+#      exit 1
+#    fi
     rm standalone_test_output.txt
   fi
 }

--- a/tests/run_standalone_tests.sh
+++ b/tests/run_standalone_tests.sh
@@ -48,11 +48,11 @@ function show_batched_output {
   if [ -f standalone_test_output.txt ]; then  # if exists
     cat standalone_test_output.txt
     # heuristic: stop if there's mentions of errors. this can prevent false negatives when only some of the ranks fail
-    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
-      echo "Potential error! Stopping."
-      rm standalone_test_output.txt
-      exit 1
-    fi
+#    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
+#      echo "Potential error! Stopping."
+#      rm standalone_test_output.txt
+#      exit 1
+#    fi
     rm standalone_test_output.txt
   fi
 }

--- a/tests/run_standalone_tests.sh
+++ b/tests/run_standalone_tests.sh
@@ -51,11 +51,11 @@ function show_batched_output {
   if [ -f standalone_test_output.txt ]; then  # if exists
     cat standalone_test_output.txt
     # heuristic: stop if there's mentions of errors. this can prevent false negatives when only some of the ranks fail
-#    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
-#      echo "Potential error! Stopping."
-#      rm standalone_test_output.txt
-#      exit 1
-#    fi
+    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
+      echo "Potential error! Stopping."
+      rm standalone_test_output.txt
+      exit 1
+    fi
     rm standalone_test_output.txt
   fi
 }


### PR DESCRIPTION
Fixes #2

The current heuristic for stopping the standalone job produces a false-positive alarm. 