### PR TITLE
Bump colossalai and Lightning version

### DIFF
--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -21,6 +21,7 @@ pr:
       - ".azure/gpu-tests.yml"
       - "tests/**"
       - "pyproject.toml"  # includes pytest config
+      - "requirements.txt"
       - "_requirements/**"
       - "src/**"
     exclude:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-# TODO: Update this once Lightning 2.0 rc is released
-lightning @ https://github.com/Lightning-AI/lightning/archive/refs/heads/master.zip
-colossalai>=0.2.0, <=0.2.4
+# TODO: Update this once Lightning 2.0.0 is released
+lightning>=2.0.0rc0
+colossalai>=0.2.0, <=0.2.5


### PR DESCRIPTION
Bump version as proposed in https://github.com/Lightning-AI/lightning/issues/16824, but also needs a cherry-pick into 1.9.x (reminder)